### PR TITLE
Fix missing reference to keymap

### DIFF
--- a/macrostep.el
+++ b/macrostep.el
@@ -487,7 +487,8 @@ and move back and forth with \\[macrostep-next-macro] and \\[macrostep-prev-macr
 Use \\[macrostep-collapse-all] or collapse all visible expansions to
 quit and return to normal editing.
 
-\\{macrostep-keymap}"
+\\{macrostep-mode-keymap}"
+  :keymap macrostep-mode-keymap
   :lighter " Macro-Stepper"
   :group 'macrostep
   (if macrostep-mode


### PR DESCRIPTION
There was no reference to the necessary keymap in the define-minor-mode call, so I fixed it (as well as the reference in the docstring). 
