### PR TITLE
[#11] Add compat dependency for defvar-keymap

### DIFF
--- a/macrostep.el
+++ b/macrostep.el
@@ -8,7 +8,7 @@
 ;; Keywords: lisp, languages, macro, debugging
 
 ;; Package-Version: 0.9.3
-;; Package-Requires: ((cl-lib "0.5"))
+;; Package-Requires: ((cl-lib "0.5") (compat "29"))
 
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -257,6 +257,8 @@
 ;;     definitions.
 
 ;;; Code:
+
+(require 'compat)
 
 (require 'pp)
 (require 'ring)


### PR DESCRIPTION
As reported in https://github.com/emacsorphanage/macrostep/issues/11. Since `straight.el` actually creates an isolated environment for compiling packages now, as was requested for many years, missing dependency declarations will actually cause compilation errors, since the byte-compiler will not be able to compile macros correctly even if the user's configuration happens to load `compat` in some other place. So, this change also fixes `straight.el` being unable to load the package properly.